### PR TITLE
Delegate content_tag_string to the tag_builder on Rails 5

### DIFF
--- a/lib/navy/renderer.rb
+++ b/lib/navy/renderer.rb
@@ -94,7 +94,12 @@ module Navy
 
     
     def div_tag(options, &block)
-      content_tag_string(:div, block.call, options, true)
+      if ActionPack::VERSION::MAJOR.to_s < '5'
+        content_tag_string(:div, block.call, options, true)
+      else
+        # Rails 5 moved this method to the tag_builder and will raise a NameError
+        tag_builder.content_tag_string(:div, block.call, options, true)
+      end
     end
 
   end


### PR DESCRIPTION
Hi @kratob,
could you have a look at this PR?

I needed this gem to keep working in Rails 5, which  moved the private `content_tag_string` method to the `tag_builder`. The version check is based on `ActionPack`, since we already defined that in the gemspec.

Thank you!